### PR TITLE
Tidying up cubits

### DIFF
--- a/app_navigator/lib/screens/home/home_cubit.dart
+++ b/app_navigator/lib/screens/home/home_cubit.dart
@@ -1,30 +1,30 @@
 import 'dart:async';
 
+import 'package:app_navigator/navigation/app_navigator.dart';
 import 'package:app_navigator/screens/home/home_state.dart';
+import 'package:app_navigator/dialog/dialog_navigation.dart' as dialog;
 import 'package:bloc/bloc.dart';
 
+import '../../banner/banner_navigation.dart';
+import '../../bottom_sheet/bottom_sheet_navigation.dart';
+
 class HomeCubit extends Cubit<HomeState> {
-  HomeCubit() : super(HomeState.loading());
+  final AppNavigator _appNavigator;
+
+  HomeCubit({required AppNavigator appNavigator})
+      : _appNavigator = appNavigator,
+        super(HomeState.loading());
 
   void loadData() {
     emit(HomeState.loading());
     waitAndThenEmit(HomeState.loaded());
   }
 
-  void showBanner() {
-    emit(HomeState.showBanner(snackbarMessage: "Hey! I'm a banner"));
-    emit(HomeState.loaded());
-  }
+  void showBanner() => _appNavigator.pushBanner(BannerRoute.example("Hey! I'm a banner"));
 
-  void showDialog() {
-    emit(HomeState.showDialog(dialogMessage: "Hey! I'm a dialog"));
-    emit(HomeState.loaded());
-  }
+  void showDialog() => _appNavigator.pushDialog(dialog.DialogRoute.example("Hey! I'm a dialog"));
 
-  void showBottomSheet() {
-    emit(HomeState.showBottomSheet(bottomSheetMessage: "Hey! I'm a bottom sheet"));
-    emit(HomeState.loaded());
-  }
+  void showBottomSheet() => _appNavigator.pushBottomSheet(BottomSheetRoute.example("Hey! I'm a bottom sheet"));
 
   Future<void> waitAndThenEmit(HomeState state) {
     return Future.delayed(const Duration(seconds: 2), () => emit(state));

--- a/app_navigator/lib/screens/home/home_injection.dart
+++ b/app_navigator/lib/screens/home/home_injection.dart
@@ -2,5 +2,5 @@ import 'package:app_navigator/screens/home/home_cubit.dart';
 import 'package:app_navigator/utilities/injection.dart';
 
 void setupHomeInjection() {
-  getIt.registerFactory(() => HomeCubit());
+  getIt.registerFactory(() => HomeCubit(appNavigator: getIt()));
 }

--- a/app_navigator/lib/screens/home/home_screen.dart
+++ b/app_navigator/lib/screens/home/home_screen.dart
@@ -1,15 +1,11 @@
-import 'package:app_navigator/banner/banner_navigation.dart';
-import 'package:app_navigator/bottom_sheet/bottom_sheet_navigation.dart';
 import 'package:app_navigator/navigation/app_navigator.dart';
 import 'package:app_navigator/screens/home/home_cubit.dart';
 import 'package:app_navigator/screens/home/home_state.dart';
 import 'package:app_navigator/screens/settings/settings_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:app_navigator/dialog/dialog_navigation.dart' as dialog;
 
 import '../../navigation/typedefs.dart';
-import '../../utilities/do_nothing.dart';
 import '../../utilities/injection.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -51,27 +47,10 @@ class _Body extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          BlocConsumer<HomeCubit, HomeState>(
-            listenWhen: (_, current) => current.maybeMap(
-              showBanner: (_) => true,
-              showDialog: (_) => true,
-              showBottomSheet: (_) => true,
-              orElse: () => false,
-            ),
-            listener: (context, state) => state.maybeWhen(
-              showBanner: (message) => getIt<AppNavigator>().pushBanner(BannerRoute.example(message)),
-              showDialog: (message) => getIt<AppNavigator>().pushDialog(dialog.DialogRoute.example(message)),
-              showBottomSheet: (message) => getIt<AppNavigator>().pushBottomSheet(BottomSheetRoute.example(message)),
-              orElse: () => doNothing('Other states are not handled'),
-            ),
-            buildWhen: (_, current) => current.maybeMap(
-              loading: (_) => true,
-              loaded: (_) => true,
-              orElse: () => false,
-            ),
-            builder: (context, state) => state.maybeWhen(
+          BlocBuilder<HomeCubit, HomeState>(
+            builder: (context, state) => state.when(
               loading: () => const CircularProgressIndicator.adaptive(),
-              orElse: () => const _LoadedWidget(),
+              loaded: () => const _LoadedWidget(),
             ),
           )
         ],

--- a/app_navigator/lib/screens/home/home_screen.dart
+++ b/app_navigator/lib/screens/home/home_screen.dart
@@ -33,7 +33,7 @@ class HomeScreen extends StatelessWidget {
         ],
       ),
       body: BlocProvider(
-        create: (_) => HomeCubit()..loadData(),
+        create: (_) => getIt<HomeCubit>()..loadData(),
         child: const _Body(),
       ),
     );

--- a/app_navigator/lib/screens/home/home_state.dart
+++ b/app_navigator/lib/screens/home/home_state.dart
@@ -7,8 +7,4 @@ part 'home_state.freezed.dart';
 class HomeState with _$HomeState {
   factory HomeState.loading() = _Loading;
   factory HomeState.loaded() = _Loaded;
-
-  factory HomeState.showBanner({required final String snackbarMessage}) = _ShowSnackbar;
-  factory HomeState.showDialog({required final String dialogMessage}) = _ShowDialog;
-  factory HomeState.showBottomSheet({required final String bottomSheetMessage}) = _ShowBottomSheet;
 }

--- a/app_navigator/lib/screens/home/home_state.freezed.dart
+++ b/app_navigator/lib/screens/home/home_state.freezed.dart
@@ -20,27 +20,18 @@ mixin _$HomeState {
   TResult when<TResult extends Object?>({
     required TResult Function() loading,
     required TResult Function() loaded,
-    required TResult Function(String snackbarMessage) showBanner,
-    required TResult Function(String dialogMessage) showDialog,
-    required TResult Function(String bottomSheetMessage) showBottomSheet,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult Function()? loading,
     TResult Function()? loaded,
-    TResult Function(String snackbarMessage)? showBanner,
-    TResult Function(String dialogMessage)? showDialog,
-    TResult Function(String bottomSheetMessage)? showBottomSheet,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? loading,
     TResult Function()? loaded,
-    TResult Function(String snackbarMessage)? showBanner,
-    TResult Function(String dialogMessage)? showDialog,
-    TResult Function(String bottomSheetMessage)? showBottomSheet,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -48,27 +39,18 @@ mixin _$HomeState {
   TResult map<TResult extends Object?>({
     required TResult Function(_Loading value) loading,
     required TResult Function(_Loaded value) loaded,
-    required TResult Function(_ShowSnackbar value) showBanner,
-    required TResult Function(_ShowDialog value) showDialog,
-    required TResult Function(_ShowBottomSheet value) showBottomSheet,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
     TResult Function(_Loading value)? loading,
     TResult Function(_Loaded value)? loaded,
-    TResult Function(_ShowSnackbar value)? showBanner,
-    TResult Function(_ShowDialog value)? showDialog,
-    TResult Function(_ShowBottomSheet value)? showBottomSheet,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_Loading value)? loading,
     TResult Function(_Loaded value)? loaded,
-    TResult Function(_ShowSnackbar value)? showBanner,
-    TResult Function(_ShowDialog value)? showDialog,
-    TResult Function(_ShowBottomSheet value)? showBottomSheet,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -136,9 +118,6 @@ class _$_Loading with DiagnosticableTreeMixin implements _Loading {
   TResult when<TResult extends Object?>({
     required TResult Function() loading,
     required TResult Function() loaded,
-    required TResult Function(String snackbarMessage) showBanner,
-    required TResult Function(String dialogMessage) showDialog,
-    required TResult Function(String bottomSheetMessage) showBottomSheet,
   }) {
     return loading();
   }
@@ -148,9 +127,6 @@ class _$_Loading with DiagnosticableTreeMixin implements _Loading {
   TResult? whenOrNull<TResult extends Object?>({
     TResult Function()? loading,
     TResult Function()? loaded,
-    TResult Function(String snackbarMessage)? showBanner,
-    TResult Function(String dialogMessage)? showDialog,
-    TResult Function(String bottomSheetMessage)? showBottomSheet,
   }) {
     return loading?.call();
   }
@@ -160,9 +136,6 @@ class _$_Loading with DiagnosticableTreeMixin implements _Loading {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? loading,
     TResult Function()? loaded,
-    TResult Function(String snackbarMessage)? showBanner,
-    TResult Function(String dialogMessage)? showDialog,
-    TResult Function(String bottomSheetMessage)? showBottomSheet,
     required TResult orElse(),
   }) {
     if (loading != null) {
@@ -176,9 +149,6 @@ class _$_Loading with DiagnosticableTreeMixin implements _Loading {
   TResult map<TResult extends Object?>({
     required TResult Function(_Loading value) loading,
     required TResult Function(_Loaded value) loaded,
-    required TResult Function(_ShowSnackbar value) showBanner,
-    required TResult Function(_ShowDialog value) showDialog,
-    required TResult Function(_ShowBottomSheet value) showBottomSheet,
   }) {
     return loading(this);
   }
@@ -188,9 +158,6 @@ class _$_Loading with DiagnosticableTreeMixin implements _Loading {
   TResult? mapOrNull<TResult extends Object?>({
     TResult Function(_Loading value)? loading,
     TResult Function(_Loaded value)? loaded,
-    TResult Function(_ShowSnackbar value)? showBanner,
-    TResult Function(_ShowDialog value)? showDialog,
-    TResult Function(_ShowBottomSheet value)? showBottomSheet,
   }) {
     return loading?.call(this);
   }
@@ -200,9 +167,6 @@ class _$_Loading with DiagnosticableTreeMixin implements _Loading {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_Loading value)? loading,
     TResult Function(_Loaded value)? loaded,
-    TResult Function(_ShowSnackbar value)? showBanner,
-    TResult Function(_ShowDialog value)? showDialog,
-    TResult Function(_ShowBottomSheet value)? showBottomSheet,
     required TResult orElse(),
   }) {
     if (loading != null) {
@@ -262,9 +226,6 @@ class _$_Loaded with DiagnosticableTreeMixin implements _Loaded {
   TResult when<TResult extends Object?>({
     required TResult Function() loading,
     required TResult Function() loaded,
-    required TResult Function(String snackbarMessage) showBanner,
-    required TResult Function(String dialogMessage) showDialog,
-    required TResult Function(String bottomSheetMessage) showBottomSheet,
   }) {
     return loaded();
   }
@@ -274,9 +235,6 @@ class _$_Loaded with DiagnosticableTreeMixin implements _Loaded {
   TResult? whenOrNull<TResult extends Object?>({
     TResult Function()? loading,
     TResult Function()? loaded,
-    TResult Function(String snackbarMessage)? showBanner,
-    TResult Function(String dialogMessage)? showDialog,
-    TResult Function(String bottomSheetMessage)? showBottomSheet,
   }) {
     return loaded?.call();
   }
@@ -286,9 +244,6 @@ class _$_Loaded with DiagnosticableTreeMixin implements _Loaded {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? loading,
     TResult Function()? loaded,
-    TResult Function(String snackbarMessage)? showBanner,
-    TResult Function(String dialogMessage)? showDialog,
-    TResult Function(String bottomSheetMessage)? showBottomSheet,
     required TResult orElse(),
   }) {
     if (loaded != null) {
@@ -302,9 +257,6 @@ class _$_Loaded with DiagnosticableTreeMixin implements _Loaded {
   TResult map<TResult extends Object?>({
     required TResult Function(_Loading value) loading,
     required TResult Function(_Loaded value) loaded,
-    required TResult Function(_ShowSnackbar value) showBanner,
-    required TResult Function(_ShowDialog value) showDialog,
-    required TResult Function(_ShowBottomSheet value) showBottomSheet,
   }) {
     return loaded(this);
   }
@@ -314,9 +266,6 @@ class _$_Loaded with DiagnosticableTreeMixin implements _Loaded {
   TResult? mapOrNull<TResult extends Object?>({
     TResult Function(_Loading value)? loading,
     TResult Function(_Loaded value)? loaded,
-    TResult Function(_ShowSnackbar value)? showBanner,
-    TResult Function(_ShowDialog value)? showDialog,
-    TResult Function(_ShowBottomSheet value)? showBottomSheet,
   }) {
     return loaded?.call(this);
   }
@@ -326,9 +275,6 @@ class _$_Loaded with DiagnosticableTreeMixin implements _Loaded {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_Loading value)? loading,
     TResult Function(_Loaded value)? loaded,
-    TResult Function(_ShowSnackbar value)? showBanner,
-    TResult Function(_ShowDialog value)? showDialog,
-    TResult Function(_ShowBottomSheet value)? showBottomSheet,
     required TResult orElse(),
   }) {
     if (loaded != null) {
@@ -340,489 +286,4 @@ class _$_Loaded with DiagnosticableTreeMixin implements _Loaded {
 
 abstract class _Loaded implements HomeState {
   factory _Loaded() = _$_Loaded;
-}
-
-/// @nodoc
-abstract class _$$_ShowSnackbarCopyWith<$Res> {
-  factory _$$_ShowSnackbarCopyWith(
-          _$_ShowSnackbar value, $Res Function(_$_ShowSnackbar) then) =
-      __$$_ShowSnackbarCopyWithImpl<$Res>;
-  $Res call({String snackbarMessage});
-}
-
-/// @nodoc
-class __$$_ShowSnackbarCopyWithImpl<$Res> extends _$HomeStateCopyWithImpl<$Res>
-    implements _$$_ShowSnackbarCopyWith<$Res> {
-  __$$_ShowSnackbarCopyWithImpl(
-      _$_ShowSnackbar _value, $Res Function(_$_ShowSnackbar) _then)
-      : super(_value, (v) => _then(v as _$_ShowSnackbar));
-
-  @override
-  _$_ShowSnackbar get _value => super._value as _$_ShowSnackbar;
-
-  @override
-  $Res call({
-    Object? snackbarMessage = freezed,
-  }) {
-    return _then(_$_ShowSnackbar(
-      snackbarMessage: snackbarMessage == freezed
-          ? _value.snackbarMessage
-          : snackbarMessage // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
-}
-
-/// @nodoc
-
-class _$_ShowSnackbar with DiagnosticableTreeMixin implements _ShowSnackbar {
-  _$_ShowSnackbar({required this.snackbarMessage});
-
-  @override
-  final String snackbarMessage;
-
-  @override
-  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'HomeState.showBanner(snackbarMessage: $snackbarMessage)';
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DiagnosticsProperty('type', 'HomeState.showBanner'))
-      ..add(DiagnosticsProperty('snackbarMessage', snackbarMessage));
-  }
-
-  @override
-  bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$_ShowSnackbar &&
-            const DeepCollectionEquality()
-                .equals(other.snackbarMessage, snackbarMessage));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(snackbarMessage));
-
-  @JsonKey(ignore: true)
-  @override
-  _$$_ShowSnackbarCopyWith<_$_ShowSnackbar> get copyWith =>
-      __$$_ShowSnackbarCopyWithImpl<_$_ShowSnackbar>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() loading,
-    required TResult Function() loaded,
-    required TResult Function(String snackbarMessage) showBanner,
-    required TResult Function(String dialogMessage) showDialog,
-    required TResult Function(String bottomSheetMessage) showBottomSheet,
-  }) {
-    return showBanner(snackbarMessage);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? loading,
-    TResult Function()? loaded,
-    TResult Function(String snackbarMessage)? showBanner,
-    TResult Function(String dialogMessage)? showDialog,
-    TResult Function(String bottomSheetMessage)? showBottomSheet,
-  }) {
-    return showBanner?.call(snackbarMessage);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? loading,
-    TResult Function()? loaded,
-    TResult Function(String snackbarMessage)? showBanner,
-    TResult Function(String dialogMessage)? showDialog,
-    TResult Function(String bottomSheetMessage)? showBottomSheet,
-    required TResult orElse(),
-  }) {
-    if (showBanner != null) {
-      return showBanner(snackbarMessage);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(_Loading value) loading,
-    required TResult Function(_Loaded value) loaded,
-    required TResult Function(_ShowSnackbar value) showBanner,
-    required TResult Function(_ShowDialog value) showDialog,
-    required TResult Function(_ShowBottomSheet value) showBottomSheet,
-  }) {
-    return showBanner(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Loading value)? loading,
-    TResult Function(_Loaded value)? loaded,
-    TResult Function(_ShowSnackbar value)? showBanner,
-    TResult Function(_ShowDialog value)? showDialog,
-    TResult Function(_ShowBottomSheet value)? showBottomSheet,
-  }) {
-    return showBanner?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(_Loading value)? loading,
-    TResult Function(_Loaded value)? loaded,
-    TResult Function(_ShowSnackbar value)? showBanner,
-    TResult Function(_ShowDialog value)? showDialog,
-    TResult Function(_ShowBottomSheet value)? showBottomSheet,
-    required TResult orElse(),
-  }) {
-    if (showBanner != null) {
-      return showBanner(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class _ShowSnackbar implements HomeState {
-  factory _ShowSnackbar({required final String snackbarMessage}) =
-      _$_ShowSnackbar;
-
-  String get snackbarMessage => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  _$$_ShowSnackbarCopyWith<_$_ShowSnackbar> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class _$$_ShowDialogCopyWith<$Res> {
-  factory _$$_ShowDialogCopyWith(
-          _$_ShowDialog value, $Res Function(_$_ShowDialog) then) =
-      __$$_ShowDialogCopyWithImpl<$Res>;
-  $Res call({String dialogMessage});
-}
-
-/// @nodoc
-class __$$_ShowDialogCopyWithImpl<$Res> extends _$HomeStateCopyWithImpl<$Res>
-    implements _$$_ShowDialogCopyWith<$Res> {
-  __$$_ShowDialogCopyWithImpl(
-      _$_ShowDialog _value, $Res Function(_$_ShowDialog) _then)
-      : super(_value, (v) => _then(v as _$_ShowDialog));
-
-  @override
-  _$_ShowDialog get _value => super._value as _$_ShowDialog;
-
-  @override
-  $Res call({
-    Object? dialogMessage = freezed,
-  }) {
-    return _then(_$_ShowDialog(
-      dialogMessage: dialogMessage == freezed
-          ? _value.dialogMessage
-          : dialogMessage // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
-}
-
-/// @nodoc
-
-class _$_ShowDialog with DiagnosticableTreeMixin implements _ShowDialog {
-  _$_ShowDialog({required this.dialogMessage});
-
-  @override
-  final String dialogMessage;
-
-  @override
-  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'HomeState.showDialog(dialogMessage: $dialogMessage)';
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DiagnosticsProperty('type', 'HomeState.showDialog'))
-      ..add(DiagnosticsProperty('dialogMessage', dialogMessage));
-  }
-
-  @override
-  bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$_ShowDialog &&
-            const DeepCollectionEquality()
-                .equals(other.dialogMessage, dialogMessage));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(dialogMessage));
-
-  @JsonKey(ignore: true)
-  @override
-  _$$_ShowDialogCopyWith<_$_ShowDialog> get copyWith =>
-      __$$_ShowDialogCopyWithImpl<_$_ShowDialog>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() loading,
-    required TResult Function() loaded,
-    required TResult Function(String snackbarMessage) showBanner,
-    required TResult Function(String dialogMessage) showDialog,
-    required TResult Function(String bottomSheetMessage) showBottomSheet,
-  }) {
-    return showDialog(dialogMessage);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? loading,
-    TResult Function()? loaded,
-    TResult Function(String snackbarMessage)? showBanner,
-    TResult Function(String dialogMessage)? showDialog,
-    TResult Function(String bottomSheetMessage)? showBottomSheet,
-  }) {
-    return showDialog?.call(dialogMessage);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? loading,
-    TResult Function()? loaded,
-    TResult Function(String snackbarMessage)? showBanner,
-    TResult Function(String dialogMessage)? showDialog,
-    TResult Function(String bottomSheetMessage)? showBottomSheet,
-    required TResult orElse(),
-  }) {
-    if (showDialog != null) {
-      return showDialog(dialogMessage);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(_Loading value) loading,
-    required TResult Function(_Loaded value) loaded,
-    required TResult Function(_ShowSnackbar value) showBanner,
-    required TResult Function(_ShowDialog value) showDialog,
-    required TResult Function(_ShowBottomSheet value) showBottomSheet,
-  }) {
-    return showDialog(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Loading value)? loading,
-    TResult Function(_Loaded value)? loaded,
-    TResult Function(_ShowSnackbar value)? showBanner,
-    TResult Function(_ShowDialog value)? showDialog,
-    TResult Function(_ShowBottomSheet value)? showBottomSheet,
-  }) {
-    return showDialog?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(_Loading value)? loading,
-    TResult Function(_Loaded value)? loaded,
-    TResult Function(_ShowSnackbar value)? showBanner,
-    TResult Function(_ShowDialog value)? showDialog,
-    TResult Function(_ShowBottomSheet value)? showBottomSheet,
-    required TResult orElse(),
-  }) {
-    if (showDialog != null) {
-      return showDialog(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class _ShowDialog implements HomeState {
-  factory _ShowDialog({required final String dialogMessage}) = _$_ShowDialog;
-
-  String get dialogMessage => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  _$$_ShowDialogCopyWith<_$_ShowDialog> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class _$$_ShowBottomSheetCopyWith<$Res> {
-  factory _$$_ShowBottomSheetCopyWith(
-          _$_ShowBottomSheet value, $Res Function(_$_ShowBottomSheet) then) =
-      __$$_ShowBottomSheetCopyWithImpl<$Res>;
-  $Res call({String bottomSheetMessage});
-}
-
-/// @nodoc
-class __$$_ShowBottomSheetCopyWithImpl<$Res>
-    extends _$HomeStateCopyWithImpl<$Res>
-    implements _$$_ShowBottomSheetCopyWith<$Res> {
-  __$$_ShowBottomSheetCopyWithImpl(
-      _$_ShowBottomSheet _value, $Res Function(_$_ShowBottomSheet) _then)
-      : super(_value, (v) => _then(v as _$_ShowBottomSheet));
-
-  @override
-  _$_ShowBottomSheet get _value => super._value as _$_ShowBottomSheet;
-
-  @override
-  $Res call({
-    Object? bottomSheetMessage = freezed,
-  }) {
-    return _then(_$_ShowBottomSheet(
-      bottomSheetMessage: bottomSheetMessage == freezed
-          ? _value.bottomSheetMessage
-          : bottomSheetMessage // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
-}
-
-/// @nodoc
-
-class _$_ShowBottomSheet
-    with DiagnosticableTreeMixin
-    implements _ShowBottomSheet {
-  _$_ShowBottomSheet({required this.bottomSheetMessage});
-
-  @override
-  final String bottomSheetMessage;
-
-  @override
-  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'HomeState.showBottomSheet(bottomSheetMessage: $bottomSheetMessage)';
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DiagnosticsProperty('type', 'HomeState.showBottomSheet'))
-      ..add(DiagnosticsProperty('bottomSheetMessage', bottomSheetMessage));
-  }
-
-  @override
-  bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$_ShowBottomSheet &&
-            const DeepCollectionEquality()
-                .equals(other.bottomSheetMessage, bottomSheetMessage));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(bottomSheetMessage));
-
-  @JsonKey(ignore: true)
-  @override
-  _$$_ShowBottomSheetCopyWith<_$_ShowBottomSheet> get copyWith =>
-      __$$_ShowBottomSheetCopyWithImpl<_$_ShowBottomSheet>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() loading,
-    required TResult Function() loaded,
-    required TResult Function(String snackbarMessage) showBanner,
-    required TResult Function(String dialogMessage) showDialog,
-    required TResult Function(String bottomSheetMessage) showBottomSheet,
-  }) {
-    return showBottomSheet(bottomSheetMessage);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? loading,
-    TResult Function()? loaded,
-    TResult Function(String snackbarMessage)? showBanner,
-    TResult Function(String dialogMessage)? showDialog,
-    TResult Function(String bottomSheetMessage)? showBottomSheet,
-  }) {
-    return showBottomSheet?.call(bottomSheetMessage);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? loading,
-    TResult Function()? loaded,
-    TResult Function(String snackbarMessage)? showBanner,
-    TResult Function(String dialogMessage)? showDialog,
-    TResult Function(String bottomSheetMessage)? showBottomSheet,
-    required TResult orElse(),
-  }) {
-    if (showBottomSheet != null) {
-      return showBottomSheet(bottomSheetMessage);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(_Loading value) loading,
-    required TResult Function(_Loaded value) loaded,
-    required TResult Function(_ShowSnackbar value) showBanner,
-    required TResult Function(_ShowDialog value) showDialog,
-    required TResult Function(_ShowBottomSheet value) showBottomSheet,
-  }) {
-    return showBottomSheet(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_Loading value)? loading,
-    TResult Function(_Loaded value)? loaded,
-    TResult Function(_ShowSnackbar value)? showBanner,
-    TResult Function(_ShowDialog value)? showDialog,
-    TResult Function(_ShowBottomSheet value)? showBottomSheet,
-  }) {
-    return showBottomSheet?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(_Loading value)? loading,
-    TResult Function(_Loaded value)? loaded,
-    TResult Function(_ShowSnackbar value)? showBanner,
-    TResult Function(_ShowDialog value)? showDialog,
-    TResult Function(_ShowBottomSheet value)? showBottomSheet,
-    required TResult orElse(),
-  }) {
-    if (showBottomSheet != null) {
-      return showBottomSheet(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class _ShowBottomSheet implements HomeState {
-  factory _ShowBottomSheet({required final String bottomSheetMessage}) =
-      _$_ShowBottomSheet;
-
-  String get bottomSheetMessage => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  _$$_ShowBottomSheetCopyWith<_$_ShowBottomSheet> get copyWith =>
-      throw _privateConstructorUsedError;
 }


### PR DESCRIPTION
## Problem
Our cubit and cubit state has states that are navigation events and don't update the UI of the screen 😬 which means that we need to implement `BlocConsumer` and have the dreaded `buildWhen` and `listenWhen` functions 😭 


## Solution
Now that we have decoupled the UI from the navigation we can use the `AppNavigator` directly inside the cubit and remove the unnecessary event based state from the cubit 😄 