### PR TITLE
Improve screen level navigation.

### DIFF
--- a/app_navigator/lib/main.dart
+++ b/app_navigator/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:app_navigator/navigation/app_navigator.dart';
-import 'package:app_navigator/screens/home/home_screen.dart';
-import 'package:app_navigator/screens/settings/settings_screen.dart';
+import 'package:app_navigator/screens/screen_navigation.dart';
 import 'package:app_navigator/utilities/injection.dart';
 import 'package:flutter/material.dart';
 
@@ -21,11 +20,8 @@ class _AppNavigatorApp extends StatelessWidget {
         primarySwatch: Colors.blue,
       ),
       navigatorKey: getIt<AppNavigator>().navigatorKey,
-      initialRoute: HomeScreen.route.key,
-      routes: Map.fromEntries([
-        HomeScreen.route,
-        SettingsScreen.route,
-      ]),
+      routes: ScreenRoutes.routes,
+      initialRoute: ScreenRoutes.initialRoute,
     );
   }
 }

--- a/app_navigator/lib/navigation/app_navigator.dart
+++ b/app_navigator/lib/navigation/app_navigator.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 
 import 'package:app_navigator/dialog/dialog_navigation.dart' as dialog;
 
+import '../screens/screen_navigation.dart';
+
 class AppNavigator {
   final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
   final BottomSheetRoutes _bottomSheetRoute = BottomSheetRoutes();
@@ -12,8 +14,11 @@ class AppNavigator {
   final BannerRoutes _bannerRoutes = BannerRoutes();
   final SnackbarRoutes _snackbarRoutes = SnackbarRoutes();
 
-  void navigateTo<T extends Object?>(String routeName, {Object? arguments}) =>
-      navigatorKey.currentState?.pushNamed(routeName, arguments: arguments);
+  Future<void> navigateTo<T extends Object?>(ScreenRoute route) async {
+    final builder = ScreenRoutes.lookupBuilderByRoute(route);
+
+    navigatorKey.currentState?.push(MaterialPageRoute(builder: builder));
+  }
 
   Future<T?> pushBottomSheet<T>(BottomSheetRoute route) async {
     assert(navigatorKey.currentContext != null, 'navigation context is null when pushing a Bottom Sheet');

--- a/app_navigator/lib/screens/home/home_cubit.dart
+++ b/app_navigator/lib/screens/home/home_cubit.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:app_navigator/navigation/app_navigator.dart';
 import 'package:app_navigator/screens/home/home_state.dart';
 import 'package:app_navigator/dialog/dialog_navigation.dart' as dialog;
+import 'package:app_navigator/screens/screen_navigation.dart';
 import 'package:bloc/bloc.dart';
 
 import '../../banner/banner_navigation.dart';
@@ -25,6 +26,8 @@ class HomeCubit extends Cubit<HomeState> {
   void showDialog() => _appNavigator.pushDialog(dialog.DialogRoute.example("Hey! I'm a dialog"));
 
   void showBottomSheet() => _appNavigator.pushBottomSheet(BottomSheetRoute.example("Hey! I'm a bottom sheet"));
+
+  void navigateToSettings() => _appNavigator.navigateTo(ScreenRoute.settings());
 
   Future<void> waitAndThenEmit(HomeState state) {
     return Future.delayed(const Duration(seconds: 2), () => emit(state));

--- a/app_navigator/lib/screens/home/home_screen.dart
+++ b/app_navigator/lib/screens/home/home_screen.dart
@@ -1,37 +1,20 @@
-import 'package:app_navigator/navigation/app_navigator.dart';
 import 'package:app_navigator/screens/home/home_cubit.dart';
 import 'package:app_navigator/screens/home/home_state.dart';
-import 'package:app_navigator/screens/settings/settings_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import '../../navigation/typedefs.dart';
 import '../../utilities/injection.dart';
 
 class HomeScreen extends StatelessWidget {
-  static RouteEntry route = RouteEntry(
-    '/',
-    (context) => const HomeScreen._(),
-  );
+  static WidgetBuilder builder = (context) => const HomeScreen._();
 
   const HomeScreen._({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('App Navigtor: The Problem'),
-        actions: [
-          IconButton(
-            onPressed: () => getIt<AppNavigator>().navigateTo(SettingsScreen.route.key),
-            icon: const Icon(Icons.settings),
-          ),
-        ],
-      ),
-      body: BlocProvider(
-        create: (_) => getIt<HomeCubit>()..loadData(),
-        child: const _Body(),
-      ),
+    return BlocProvider(
+      create: (_) => getIt<HomeCubit>()..loadData(),
+      child: const _Body(),
     );
   }
 }
@@ -43,17 +26,28 @@ class _Body extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          BlocBuilder<HomeCubit, HomeState>(
-            builder: (context, state) => state.when(
-              loading: () => const CircularProgressIndicator.adaptive(),
-              loaded: () => const _LoadedWidget(),
-            ),
-          )
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('App Navigtor: The Problem'),
+        actions: [
+          IconButton(
+            onPressed: () => context.read<HomeCubit>().navigateToSettings(),
+            icon: const Icon(Icons.settings),
+          ),
         ],
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            BlocBuilder<HomeCubit, HomeState>(
+              builder: (context, state) => state.when(
+                loading: () => const CircularProgressIndicator.adaptive(),
+                loaded: () => const _LoadedWidget(),
+              ),
+            )
+          ],
+        ),
       ),
     );
   }

--- a/app_navigator/lib/screens/screen_navigation.dart
+++ b/app_navigator/lib/screens/screen_navigation.dart
@@ -1,0 +1,36 @@
+import 'package:app_navigator/screens/home/home_screen.dart';
+import 'package:app_navigator/screens/settings/settings_screen.dart';
+import 'package:flutter/widgets.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'screen_navigation.freezed.dart';
+
+class ScreenRoutes {
+  static Map<String, WidgetBuilder> routes = {for (var element in _routes) element._routeName(): element._builder()};
+
+  static final _routes = [
+    ScreenRoute.home(),
+    ScreenRoute.settings(),
+  ];
+
+  static String initialRoute = ScreenRoute.home()._routeName();
+
+  static WidgetBuilder lookupBuilderByRoute(ScreenRoute route) => route._builder();
+}
+
+@freezed
+class ScreenRoute with _$ScreenRoute {
+  const ScreenRoute._();
+  factory ScreenRoute.settings() = _Settings;
+  factory ScreenRoute.home() = _Home;
+
+  String _routeName() => when(
+        home: () => '/',
+        settings: () => '/settings',
+      );
+
+  WidgetBuilder _builder() => when(
+        home: () => HomeScreen.builder,
+        settings: () => SettingsScreen.builder,
+      );
+}

--- a/app_navigator/lib/screens/screen_navigation.freezed.dart
+++ b/app_navigator/lib/screens/screen_navigation.freezed.dart
@@ -1,0 +1,281 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'screen_navigation.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$ScreenRoute {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() settings,
+    required TResult Function() home,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function()? settings,
+    TResult Function()? home,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? settings,
+    TResult Function()? home,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Settings value) settings,
+    required TResult Function(_Home value) home,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Settings value)? settings,
+    TResult Function(_Home value)? home,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Settings value)? settings,
+    TResult Function(_Home value)? home,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ScreenRouteCopyWith<$Res> {
+  factory $ScreenRouteCopyWith(
+          ScreenRoute value, $Res Function(ScreenRoute) then) =
+      _$ScreenRouteCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$ScreenRouteCopyWithImpl<$Res> implements $ScreenRouteCopyWith<$Res> {
+  _$ScreenRouteCopyWithImpl(this._value, this._then);
+
+  final ScreenRoute _value;
+  // ignore: unused_field
+  final $Res Function(ScreenRoute) _then;
+}
+
+/// @nodoc
+abstract class _$$_SettingsCopyWith<$Res> {
+  factory _$$_SettingsCopyWith(
+          _$_Settings value, $Res Function(_$_Settings) then) =
+      __$$_SettingsCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$_SettingsCopyWithImpl<$Res> extends _$ScreenRouteCopyWithImpl<$Res>
+    implements _$$_SettingsCopyWith<$Res> {
+  __$$_SettingsCopyWithImpl(
+      _$_Settings _value, $Res Function(_$_Settings) _then)
+      : super(_value, (v) => _then(v as _$_Settings));
+
+  @override
+  _$_Settings get _value => super._value as _$_Settings;
+}
+
+/// @nodoc
+
+class _$_Settings extends _Settings {
+  _$_Settings() : super._();
+
+  @override
+  String toString() {
+    return 'ScreenRoute.settings()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$_Settings);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() settings,
+    required TResult Function() home,
+  }) {
+    return settings();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function()? settings,
+    TResult Function()? home,
+  }) {
+    return settings?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? settings,
+    TResult Function()? home,
+    required TResult orElse(),
+  }) {
+    if (settings != null) {
+      return settings();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Settings value) settings,
+    required TResult Function(_Home value) home,
+  }) {
+    return settings(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Settings value)? settings,
+    TResult Function(_Home value)? home,
+  }) {
+    return settings?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Settings value)? settings,
+    TResult Function(_Home value)? home,
+    required TResult orElse(),
+  }) {
+    if (settings != null) {
+      return settings(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Settings extends ScreenRoute {
+  factory _Settings() = _$_Settings;
+  _Settings._() : super._();
+}
+
+/// @nodoc
+abstract class _$$_HomeCopyWith<$Res> {
+  factory _$$_HomeCopyWith(_$_Home value, $Res Function(_$_Home) then) =
+      __$$_HomeCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$_HomeCopyWithImpl<$Res> extends _$ScreenRouteCopyWithImpl<$Res>
+    implements _$$_HomeCopyWith<$Res> {
+  __$$_HomeCopyWithImpl(_$_Home _value, $Res Function(_$_Home) _then)
+      : super(_value, (v) => _then(v as _$_Home));
+
+  @override
+  _$_Home get _value => super._value as _$_Home;
+}
+
+/// @nodoc
+
+class _$_Home extends _Home {
+  _$_Home() : super._();
+
+  @override
+  String toString() {
+    return 'ScreenRoute.home()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$_Home);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() settings,
+    required TResult Function() home,
+  }) {
+    return home();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function()? settings,
+    TResult Function()? home,
+  }) {
+    return home?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? settings,
+    TResult Function()? home,
+    required TResult orElse(),
+  }) {
+    if (home != null) {
+      return home();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Settings value) settings,
+    required TResult Function(_Home value) home,
+  }) {
+    return home(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Settings value)? settings,
+    TResult Function(_Home value)? home,
+  }) {
+    return home?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Settings value)? settings,
+    TResult Function(_Home value)? home,
+    required TResult orElse(),
+  }) {
+    if (home != null) {
+      return home(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Home extends ScreenRoute {
+  factory _Home() = _$_Home;
+  _Home._() : super._();
+}

--- a/app_navigator/lib/screens/settings/settings_screen.dart
+++ b/app_navigator/lib/screens/settings/settings_screen.dart
@@ -1,12 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../../navigation/typedefs.dart';
-
 class SettingsScreen extends StatelessWidget {
-  static RouteEntry route = RouteEntry(
-    '/settings',
-    (context) => const SettingsScreen._(),
-  );
+  static WidgetBuilder builder = (context) => const SettingsScreen._();
 
   const SettingsScreen._({Key? key}) : super(key: key);
 


### PR DESCRIPTION
## Problem
I goofed on the screen level navigation and forgot to move it over to the new system. 

## Solution
This one was a little trickier because we need to supply a `Map<String, WidgetBuilder>` to the `MaterialApp`. I've hidden all of the logic for doing this inside the `ScreenRoutes` and callers who want to perform navigation can still go through the `AppNavigator` by passing a `ScreenRoute.home()` etc 😄 